### PR TITLE
fix issue #5 - checks if the project exists before changing to it

### DIFF
--- a/bin/project
+++ b/bin/project
@@ -24,8 +24,15 @@ _listprojects() {
 }
 
 _changeproject() {
-    echo "$1" > "$STATEDIR/active-project"
-    echo "active project is now: $1"
+    if [ -f "$STATEDIR/projects/$1" ]; then
+        echo "$1" > "$STATEDIR/active-project"
+        echo "active project is now: $1"
+    else
+        echo "Warning - tried to change to a non existing project."
+        echo "If you want to create it use the command:"
+        echo
+        echo "  project add $1"
+    fi
 }
 
 _showactiveproject() {


### PR DESCRIPTION
It now checks if the project is in the STATEDIR/projects/ folder before attempting to change to it.
Also, gives a nice message to the user if it tries to change project to a non-existing one.