### PR TITLE
make it possible to cd by default when doing: 'goto <magicword>'

### DIFF
--- a/bin/goto
+++ b/bin/goto
@@ -10,13 +10,15 @@ if [ "$1" = "cd" ]
 	path=`goto show "$2"`
 	cd "$path"
 else
-
     if [ "$#" -eq 1 ]; then
-        path=$(python /usr/local/opt/goto/the_real_goto.py "$GOTOPATH" show "$2")
+
+        path=$(python /usr/local/opt/goto/the_real_goto.py "$GOTOPATH" show "$1")
         if [ -d "$path" ]; then
             cd "$path"
-            exit
+            echo "cding"
+            return 0
         fi
+
     fi
 
 	python /usr/local/opt/goto/the_real_goto.py "$GOTOPATH" "$@"

--- a/bin/goto
+++ b/bin/goto
@@ -10,5 +10,14 @@ if [ "$1" = "cd" ]
 	path=`goto show "$2"`
 	cd "$path"
 else
+
+    if [ "$#" -eq 1 ]; then
+        path=$(python /usr/local/opt/goto/the_real_goto.py "$GOTOPATH" show "$2")
+        if [ -d "$path" ]; then
+            cd "$path"
+            exit
+        fi
+    fi
+
 	python /usr/local/opt/goto/the_real_goto.py "$GOTOPATH" "$@"
 fi

--- a/bin/goto
+++ b/bin/goto
@@ -1,32 +1,36 @@
 #!/bin/bash
 
 PROJECT=`cat ${HOME}/.goto/active-project`
-GOTOPATH="${HOME}/.goto/projects/${PROJECT}.json"
+PROJECTFILE="${HOME}/.goto/projects/${PROJECT}.json"
 GOTO="/usr/local/opt/goto/the_real_goto.py"
 
+# Special case 1 (goto cd <magicword>)
 if [ "$1" = "cd" ]
 	then
 	# hack to cd in this shell to the ouput of goto show <magicword>
 	path=`goto show "$2"`
 	cd "$path"
-else
-    if [ "$#" -eq 1 ]; then
-
-        # if run like: goto <magicword> 
-        path=$(goto show "$1")
-
-        # if path is folder, cd to folder
-        if [ -d "$path" ]; then
-            cd "$path"
-            return 0
-
-        # if path is file, open file
-        elif [ -f "$path" ]; then
-            goto -f "$1"
-            return 0
-        fi
-
-    fi
-
-	python /usr/local/opt/goto/the_real_goto.py "$GOTOPATH" "$@"
+    return 0
 fi
+
+
+# Special case 2  (goto <magicword>)
+if [ "$#" -eq 1 ]; then
+
+    # if run like: goto <magicword> 
+    path=$(goto show "$1")
+
+    # if path is folder, cd to folder
+    if [ -d "$path" ]; then
+        cd "$path"
+        return 0
+
+    # if path is file, open file
+    elif [ -f "$path" ]; then
+        goto -f "$1"
+        return 0
+    fi
+fi
+
+# General case
+python "$GOTO" "$PROJECTFILE" "$@"

--- a/bin/goto
+++ b/bin/goto
@@ -12,9 +12,17 @@ if [ "$1" = "cd" ]
 else
     if [ "$#" -eq 1 ]; then
 
+        # if run like: goto <magicword> 
         path=$(goto show "$1")
+
+        # if path is folder, cd to folder
         if [ -d "$path" ]; then
             cd "$path"
+            return 0
+
+        # if path is file, open file
+        elif [ -f "$path" ]; then
+            goto -f "$1"
             return 0
         fi
 

--- a/bin/goto
+++ b/bin/goto
@@ -5,8 +5,7 @@ PROJECTFILE="${HOME}/.goto/projects/${PROJECT}.json"
 GOTO="/usr/local/opt/goto/the_real_goto.py"
 
 # Special case 1 (goto cd <magicword>)
-if [ "$1" = "cd" ]
-	then
+if [ "$1" = "cd" ]; then
 	# hack to cd in this shell to the ouput of goto show <magicword>
 	path=`goto show "$2"`
 	cd "$path"

--- a/bin/goto
+++ b/bin/goto
@@ -12,10 +12,9 @@ if [ "$1" = "cd" ]
 else
     if [ "$#" -eq 1 ]; then
 
-        path=$(python /usr/local/opt/goto/the_real_goto.py "$GOTOPATH" show "$1")
+        path=$(goto show "$1")
         if [ -d "$path" ]; then
             cd "$path"
-            echo "cding"
             return 0
         fi
 


### PR DESCRIPTION
Had to not use goto in goto.sh in order to avoid very long recursive loop.