### PR TITLE
Auto assume a non-file entry without scheme is a http uri.

### DIFF
--- a/gotomagic/magic.py
+++ b/gotomagic/magic.py
@@ -139,6 +139,13 @@ def parse_uri(raw_uri):
     if os.path.exists(candidate):
         return candidate
     else:
+        # it is not a file or directory
+        # So it must be an uri.
+        # But which kind?
+        if "://" not in raw_uri:
+            # Assume it is http if no scheme is specified
+            # because that is what kids do these days
+            return "http://%s" % raw_uri
         return raw_uri
 
 


### PR DESCRIPTION
Now doing this:

`goto add ulv.no`

Will magically be understood by goto to mean:
`http://ulv.no`

If there is a folder named ulv.no, goto understands that you meant that folder.


I'm not adding https as the assumed scheme, because it may still (in 2018) break alot of sites.. It is up to the site owners to make proper http to https redirects on their domain to make surfing a safe activity on the webs.