### PR TITLE
Feature/linux sudocheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,38 +20,16 @@ In example:
  
 ### Setup 
 
-#### Mac OS-X
-
-Please note no sudo
-
+#### Mac OS-X / Linux
 ```
 git clone https://github.com/technocake/goto
 cd goto 
 ./install.sh
 ```
-
-#### Linux
-Please note the added sudo
-
-```
-git clone https://github.com/technocake/goto
-cd goto 
-sudo ./install.sh
-```
+After install, close and reopen your terminal.
 
 #### Windows (using gitbash)
-```
-# open git bash as Administrator
-git clone https://github.com/technocake/goto
-cd goto 
-./install.sh
-# If asked anything, say yes
-```
-Now you can test it. No need to close the terminal.
-
-```
-goto goto
-```
+Do the same as above, but **open git bash as Administrator**
 
 
 ### Usage

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ function should_be_sudo_on_linux {
 
 
 function should_be_admin_on_windows {
-    # Detect admin in windows
+    # Detect missing admin in windows
     if [[ ! -z $(env | grep SESSIONNAME) ]]; then
         echo "On windows using git bash, install must be run as admin"
         echo "Right click git bash and start in admin mode to try again"
@@ -67,7 +67,6 @@ fi
 
 
 
-
 echo Step 3: Setting up magic data folder in ${HOME}/.goto
 MAGICPATH="${HOME}/.goto"
 if [[ ! -d "$MAGICPATH" ]]; then
@@ -79,9 +78,8 @@ if [[ ! -d "$MAGICPATH" ]]; then
     chmod_goto_folder
 fi
 
-# add init_script to.bash_profile:
 
-
+echo Step 4: add goto startup script to bash config file
 if [ -f "${HOME}/.bash_profile" ]; then
     echo 
     echo "Next step is required to make goto work:"

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,23 @@
      
 INSTALL_DIR=/usr/local/opt/goto
 
-function should_be_sudo {
+
+function should_be_sudo_on_linux {
     if [[ "$(uname)" == "Linux" && -z $SUDO_USER ]]; then
         echo "On linux this install script needs to run with sudo"
         echo "Run again like this:" 
         echo
         echo "  sudo ./install.sh"
+        exit 1
+    fi
+}
+
+
+function should_be_admin_on_windows {
+    # Detect admin in windows
+    if [[ ! -z $(env | grep SESSIONNAME) ]]; then
+        echo "On windows using git bash, install must be run as admin"
+        echo "Right click git bash and start in admin mode to try again"
         exit 1
     fi
 }
@@ -22,8 +33,14 @@ function chmod_goto_folder {
     fi
 }
 
-# Step 0: on linux, be sudo
-should_be_sudo
+# Step 0: on linux, be sudo. on windows be admin.
+PLATFORM=$(uname -s)
+case "$PLATFORM" in
+    Linux*)   should_be_sudo_on_linux;;
+    CYGWIN*)  should_be_admin_on_windows;;
+    MINGW*)  should_be_admin_on_windows;;
+esac
+
 
 echo Step 1: Installing goto into $INSTALL_DIR 
 mkdir -p $INSTALL_DIR || check_status

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 . bin/_gotoutils # load common utils 
-
+     
 INSTALL_DIR=/usr/local/opt/goto
+
+function should_be_sudo {
+    if [[ "$(uname)" == "Linux" && -z $SUDO_USER ]]; then
+        echo "On linux this install script needs to run with sudo"
+        echo "Run again like this:" 
+        echo
+        echo "  sudo ./install.sh"
+        exit 1
+    fi
+}
+
 
 function chmod_goto_folder {
     # If run by sudo, chown folders from root to user
@@ -11,6 +22,8 @@ function chmod_goto_folder {
     fi
 }
 
+# Step 0: on linux, be sudo
+should_be_sudo
 
 echo Step 1: Installing goto into $INSTALL_DIR 
 mkdir -p $INSTALL_DIR || check_status


### PR DESCRIPTION
By adding a check for both linux and if the user runs install through sudo or not, 
we can simplify the install instructions in the README. 

This way, all three environments will be able to install running the same three lines:
 1 clone repo
 2 cd into repo
 3 ./install.sh

If the linux user tries to install without sudo, a helping message will display:

![linuxinstall](https://user-images.githubusercontent.com/1152171/45922491-5cd77f80-becd-11e8-883e-700fa0e0effa.gif)
 