### PR TITLE
add IntelliJ launch command to goto

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ If you add a shortcut to a folder, and name it "code"...
     goto add code <path to folder with code>
     
 ...this command will open folder with Sublime Text
-    goto subl                               
+    goto subl
+
+...IntelliJ:  goto idea,  VSCode: goto vscode                               
 ```
 
 

--- a/goto/gotomagic/handlers.py
+++ b/goto/gotomagic/handlers.py
@@ -10,6 +10,8 @@ import webbrowser
 import os
 import sys
 
+from .utils import detect_platform
+
 
 def parse_magic_word(current_project, word):
     """ parses words in format of either:
@@ -31,21 +33,50 @@ def copy_to_clipboard(url):
 
 
 def open_sublime(code):
-    "hack"
-    subprocess.call('subl "%s"' % code, shell=True)
+    """
+        Launches Sublime Text in the code folder via the subl cli-command.
+
+        throws
+            subprocess.CalledProcessError if not able to run the subl command.
+    """
+    subprocess.check_call('subl "%s"' % code, shell=True)
+
 
 def open_vscode(code):
-    "hack"
-    subprocess.call('code "%s"' % code, shell=True)
+    """
+        Launches Visual Studio Code in the code folder via cli.
+
+        throws
+            subprocess.CalledProcessError if not able to run the code command.
+    """
+    subprocess.check_call('code "%s"' % code, shell=True)
+
+
+def open_intellij(code):
+    """
+        Launches IntelliJ from command line and opens it in the code folder.
+
+        throws
+            subprocess.CalledProcessError if not able to run the idea command.
+    """
+    platform = detect_platform()
+
+    if platform in ['osx', 'linux']:
+        cmd = "idea"
+    elif platform == 'win':
+        cmd = "idea.exe"
+    subprocess.check_call('%s "%s"' % (cmd, code), shell=True)
+
 
 def open_folder(folder):
     "opens folders"
     folder = os.path.expanduser(folder)
-    if sys.platform in ['linux', 'linux2']:
+    platform = detect_platform()
+    if platform == 'linux':
         subprocess.call('xdg-open "%s"' % folder, shell=True)
-    elif sys.platform in ['darwin']:
+    elif platform == 'osx':
         subprocess.call('open "%s"' % folder, shell=True)
-    elif sys.platform in ['win32']:
+    elif platform == 'win':
         subprocess.call('start "%s"' % folder, shell=True)
 
 

--- a/goto/gotomagic/text.py
+++ b/goto/gotomagic/text.py
@@ -102,5 +102,39 @@ Oh noes...!
 
     Feel free to create a new issue if one does not already exist.
 
-    """
+    """,
+
+    subl_launch_failed="""
+Error: could not launch Sublime Text
+
+    This is most likely due to not having the subl command in path.
+
+    For more info see:
+        http://docs.sublimetext.info/en/latest/command_line/command_line.html
+""",
+
+    intellij_launch_failed="""
+Error:  could not launch IntelliJ.
+
+    This is most likely due to not having set up the IntelliJ
+    Command Launching yet.
+
+    To be able to launch IntelliJ from the command line,
+    this feature must be activated from the IntelliJ menu on your system.
+
+    For more info, see:
+
+        https://www.jetbrains.com/help/idea/working-with-the-ide-features-from-command-line.html
+    """,
+
+    vscode_launch_failed="""
+Error: could not launch vscode
+
+    This is most likely due to not having set up the vscode
+    Command Launching yet.
+
+    For more info, see:
+
+        https://code.visualstudio.com/docs/editor/command-line
+    """,
 )

--- a/goto/gotomagic/utils.py
+++ b/goto/gotomagic/utils.py
@@ -1,0 +1,15 @@
+import sys
+
+
+def detect_platform():
+    """
+        Detects if we are on osx, linux or win
+    """
+
+    if sys.platform in ['linux', 'linux2']:
+        return 'linux'
+    elif sys.platform in ['darwin']:
+        return 'osx'
+    elif sys.platform in ['win32']:
+        return 'win'
+    raise Exception("Error: Unknown platform. Could not determine if running linux, osx or windows")  # noqa

--- a/goto/the_real_goto.py
+++ b/goto/the_real_goto.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import sys
 import codecs
+import subprocess
 
 from .gotomagic.handlers import *
 from .gotomagic.magic import GotoMagic, is_file
@@ -48,8 +49,8 @@ def usage():
     ...this command will open folder with Sublime Text
         goto subl
 
-    ...this command will open folder with Visual Studio Code Text
-        goto vscode
+    Other editors supported:
+    Visual Studio Code: goto vscode | IntelliJ: goto idea    
     """  # noqa
 
 
@@ -122,6 +123,10 @@ def main():
                 open_sublime(magic['code'])
             except KeyError:
                 print(text.warning["no_magicword_named_code"])
+                exit(1)
+            except subprocess.CalledProcessError:
+                print(text.error["subl_launch_failed"])
+                exit(1)
             exit(0)
 
         if sys.argv[2] == 'vscode':
@@ -129,6 +134,21 @@ def main():
                 open_vscode(magic['code'])
             except KeyError:
                 print(text.warning["no_magicword_named_code"])
+                exit(1)
+            except subprocess.CalledProcessError:
+                print(text.error["vscode_launch_failed"])
+                exit(1)
+            exit(0)
+
+        if sys.argv[2] in ['intellij', 'idea']:
+            try:
+                open_intellij(magic['code'])
+            except KeyError:
+                print(text.warning["no_magicword_named_code"])
+                exit(1)
+            except subprocess.CalledProcessError:
+                print(text.error["intellij_launch_failed"])
+                exit(1)
             exit(0)
 
         if '-o' in sys.argv or '--open' in sys.argv or 'open' in sys.argv:


### PR DESCRIPTION
Alse check the actual launch-command execution.
On error, the user is informed on tips to set up
Command Line Launching for these tools:
 Sublime Text, IntelliJ, VSCode