### PR TITLE
Zsh

### DIFF
--- a/bin/_gotoutils
+++ b/bin/_gotoutils
@@ -41,10 +41,12 @@ function load_gotopath {
 }
 
 function find_rc_file {
+    local INVOKING_SHELL
     local RCFILE
+    INVOKING_SHELL="$1"
 
     # supports ~/.bashrc ~/.bash_profile and ~/.zshrc
-    if [ -n "$ZSH_VERSION" ]; then
+    if [[ "$INVOKING_SHELL" == *zsh* ]]; then
         RCFILE="${HOME}/.zshrc"
 
     elif [ -n "$BASH_VERSION" ]; then
@@ -68,9 +70,11 @@ function find_rc_file {
 
 function write_init_command_to_rcfile {
     # Handles writing the right thing to rcfile
+    local INVOKING_SHELL
     local RCFILE
+    INVOKING_SHELL="$1"
+    RCFILE=$(find_rc_file "$INVOKING_SHELL")
 
-    RCFILE=$(find_rc_file)
     if [ -z "$RCFILE" ]; then
         echo "Error finding RCfile" >&2 && exit 1
     fi

--- a/bin/goto
+++ b/bin/goto
@@ -30,18 +30,18 @@ function _goto_main {
         if [ -z "$PROJECT" ]; then
             echo "Ah hoy!" >&2
             echo >&2
-            echo "Error: Goto has no active project selected currently. " >&2
+            echo "Goto has no project context set." >&2
             echo >&2
+            echo "An example project is bundled with goto, it is called goto." >&2
+            echo "You may try  it by typing:" >&2
             echo >&2
-            echo "To activate a project type:" >&2
+            echo "     project goto" >&2
             echo >&2
-            echo "       project <project-name>" >&2
-            echo >&2
-            echo >&2
-            echo "For more help about projects in goto, type:" >&2
-            echo >&2
-            echo "      project help" >&2
-            echo >&2
+            echo "Other usefull commands to work with projects:" >&2
+            echo "    create project:   project add <project-name>" >&2
+            echo "    more help:        project help" >&2
+
+            
             return 1
         fi
 
@@ -58,15 +58,15 @@ function _goto_main {
         if [ "$#" -eq 1 ]; then
 
             # if run like: goto <magicword> 
-            path=$(goto show "$1")
+            URI=$(goto show "$1")
 
             # if path is folder, cd to folder
-            if [ -d "$path" ]; then
-                cd "$path"
+            if [ -d "$URI" ]; then
+                cd "$URI" || echo "Ah hoy - tried to cd to a non-existent path: $URI" >&2
                 return 0
 
             # if path is file, open file
-            elif [ -f "$path" ]; then
+            elif [ -f "$URI" ]; then
                 goto open "$1"
                 return 0
             fi

--- a/bin/install_goto
+++ b/bin/install_goto
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-local INVOKING_SHELL
 # Get cmd of parent pid to determine shell
 INVOKING_SHELL=$(ps -ef $(ps -ef $$ | awk '{ print $3}' | sed -n 2p) | awk '{ print $8}' | sed -n 2p)
 

--- a/bin/install_goto
+++ b/bin/install_goto
@@ -1,3 +1,8 @@
+#!/usr/bin/env bash
+
+local INVOKING_SHELL
+# Get cmd of parent pid to determine shell
+INVOKING_SHELL=$(ps -ef $(ps -ef $$ | awk '{ print $3}' | sed -n 2p) | awk '{ print $8}' | sed -n 2p)
 
 . _gotoutils # load common utils 
 load_gotopath
@@ -8,22 +13,27 @@ create_goto_folders "$GOTOPATH" || check_status
 
 
 echo "Step 2: add goto startup script to bash config file"
-write_init_command_to_rcfile
+write_init_command_to_rcfile "$INVOKING_SHELL"
 echo "Close and reopen your terminal, and goto will now work it's magic."
 
 
 # make goto ready -- now.
 source start_goto || check_status
 
-# add your first project
-project add goto || check_status
 
-# set the context to this project
-project goto || check_status
+# Set up goto project if it is not present already.
+if [ ! -f "$GOTOPATH/projects/goto.json" ]; then
+    # add your first project
+    project add goto || check_status
 
-# add your first shortcuts
-goto add goto https://github.com/technocake/goto || check_status
-goto add github https://github.com/technocake/goto || check_status
+    # set the context to this project
+    project goto || check_status
 
+    # add your first shortcuts
+    goto add goto https://github.com/technocake/goto || check_status
+    goto add github https://github.com/technocake/goto || check_status
+fi
+
+project deactivate
 
 echo Installation Succesful!

--- a/goto/commands/add.py
+++ b/goto/commands/add.py
@@ -1,5 +1,6 @@
 from ..gotomagic.text import GotoError, GotoWarning
 
+
 def add(magic, args):
     """
     Add magicword

--- a/goto/gotomagic/git.py
+++ b/goto/gotomagic/git.py
@@ -1,0 +1,132 @@
+# git.py
+import os
+import sys
+import git
+from .magic import GotoMagic
+
+
+# HACK HACK
+GOTOPATH = os.environ.get('GOTOPATH', os.path.expanduser('~/.goto'))
+
+
+
+class GitMagic():
+    """ Goto's Black Git box.
+
+        Nah, not really, it is just the place where
+        magic shortcuts are created, updated, removed and
+        used.
+
+        .. except also commited, and pushed.
+
+        tl-dr: saving magic as json - then gitify the experience.
+        https://gitpython.readthedocs.io/en/stable/tutorial.html
+    """
+
+    def __init__(self, project):
+        """ Loads json from jfile """
+        shared_file = os.path.join(
+            GOTOPATH, 'projects', 'shared', project, '{}.json'.format(project)
+        )
+
+        shared_folder = os.path.dirname(shared_file)
+        if not os.path.exists(shared_folder):
+            os.makedirs(shared_folder)
+
+        if not is_git_repo(shared_folder):
+            self.repo = git.Repo.init(shared_folder)
+        else:
+            self.repo = git.Repo(shared_folder)
+
+        shared_magic = GotoMagic(shared_file)
+        self.magic = shared_magic
+
+    def reload(self):
+        """ reload the underlaying magic """
+        self.magic.reload()
+
+    def share(self):
+        """
+        Interpreting a share as to push to a remote.
+        For now.
+        """
+        gotohub = self.repo.remotes.gotohub
+        # may raise git.exc.GitCommandError
+        gotohub.pull('master')
+        gotohub.push('master')
+
+
+    def save(self):
+        """ Saves the magic to jsonfile jfile """
+        self.magic.save()
+        self.repo.git.add(self.magic.jfile)
+        self.repo.index.commit(self.message)
+
+    def add_shortcut(self, magicword, uri):
+        """ Adds a magic shortcut if it does not exist yet.
+            If it exists, it warns the user.
+        """
+        self.magic.add_shortcut(magicword, uri)
+        self.message = "add magicword {}".format(magicword)
+
+    def update_shortcut(self, magicword, uri):
+        """ Simply overwrites the content of the magicword """
+        self.magic.update_shortcut(magicword, uri)
+        self.message = "update magicword {}".format(magicword)
+
+    def remove_shortcut(self, magicword):
+        """ Simply removes a shortcut """
+        self.magic.remove_shortcut(magicword)
+        self.message = "rm magicword {}".format(magicword)
+
+    def show_shortcut(self, magicword):
+        """ shows a shortcut """
+        self.magic.show_shortcut(magicword)
+
+    def get_uri(self, magicword):
+        return self.magic.get_uri(magicword)
+
+    def list_shortcuts(self, verbose=False):
+        """ Lists all magicwords.
+            Optionally may list verbosedly all uris too
+            if verbose = True.
+        """
+        self.magic.list_shortcuts(verbose)
+
+    def __getitem__(self, key):
+        """
+            Makes it possible to do print(magic[magiword])
+        """
+        return self.magic[key]
+
+    def __missing__(self, key):
+        """
+            ux when magicword is missing
+        """
+        self.magic.__missing__(key)
+
+    def __setitem__(self, key, value):
+        """ sets a magicword. Brutal style """
+        self.message = "set magicword {}".format(key)
+        self.magic[key] = value
+
+    def __delitem__(self, key):
+        """ removes a magicword. Brutal style """
+        self.message = "rm magicword {}".format(key)
+        self.magic.__delitem__(key)
+
+    def __len__(self):
+        """ returns number of magicwords. """
+        return len(self.magic)
+
+    def keys(self):
+        return self.magic.keys()
+
+
+
+def is_git_repo(path):
+    try:
+        _ = git.Repo(path).git_dir
+        return True
+    except git.exc.InvalidGitRepositoryError:
+        return False

--- a/goto/gotomagic/magic.py
+++ b/goto/gotomagic/magic.py
@@ -25,6 +25,10 @@ class GotoMagic():
         self.jfile = jfile
         self.magic = load_magic(jfile)
 
+    def reload(self):
+        """ reload the magic """
+        self.__init__(self.jfile)
+
     def save(self):
         """ Saves the magic to jsonfile jfile """
         save_magic(self.jfile, self.magic)
@@ -129,6 +133,9 @@ class GotoMagic():
     def __len__(self):
         """ returns number of magicwords. """
         return len(self.magic.keys())
+
+    def keys(self):
+        return self.magic.keys()
 
 
 def parse_uri(raw_uri):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyperclip
+gitpython

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,3 @@
 tox
+pyperclip
+gitpython

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setuptools.setup(
     },
     packages=find_packages(where='.'),
     install_requires=[
-        'pyperclip'
+        'pyperclip',
+        'gitpython',
     ],
     scripts=[
         'bin/goto',


### PR DESCRIPTION
Properly finds a way to check if zsh is the executing shell, regardless of the default shell.
This makes it possible to suggest the correct RC_FILE to use in the `install_goto` script.

For the rest of the binaries, the shell should be set to bash, for now (the non-interactive parts of goto).

There is a Milestone  to be going for after this:  Zsh autocompletions. 