### PR TITLE
Feature/warn user about ampersand

### DIFF
--- a/bin/goto
+++ b/bin/goto
@@ -6,7 +6,6 @@
 [[ -n $BASH_VERSION ]] && (return 0 2>/dev/null)) && _GOTO_IS_SOURCED=0 || _GOTO_IS_SOURCED=1
 
 
-
 function _goto_main {
     local PROJECT PROJECTFILE URI
 

--- a/goto/gotomagic/text/warning.py
+++ b/goto/gotomagic/text/warning.py
@@ -90,5 +90,24 @@ Ah hoy!
 
     example:
         goto {command} website http://example.org
-    """
+    """,
+
+    unescaped_ampersand_url_detected="""
+Ah hoy!
+    - Detected an ampersand (&) in the uri.
+
+    Since goto is ran in a shell, unescaped &'s will make
+    goto run in the background, with only half of the uri
+    you intended to give it.
+    This is expected behaviour in bash/zsh.
+
+    Effectively, chopping your url in half.
+
+    Example: http://example.com?query=param&query2=param
+    would loose everything after the & character.
+
+    Try again, but this time wrap the url with "":
+
+        goto {command} {magicword} "http://your-url?a=1&b=2"
+    """,
 )

--- a/goto/gotomagic/utils.py
+++ b/goto/gotomagic/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from ..gotomagic.text import GotoWarning
 
 
 def detect_platform():
@@ -20,3 +21,51 @@ def is_file(raw_uri):
     ''' checks if the file or folder exist and returns True if so '''
     candidate = os.path.abspath(raw_uri)
     return os.path.exists(candidate)
+
+
+def detect_unescaped_ampersand_url():
+    '''
+        Detects if user has entered a url with ampersand,
+        and accidentaly launched goto in the background,
+        cutting the url in half
+
+        based on
+        https://stackoverflow.com/questions/24861351/how-to-detect-if-python-script-is-being-run-as-a-background-process
+    '''
+    if len(sys.argv) < 3:
+        return False
+    command = sys.argv[2]
+    if command in ['add', 'update']:
+        try:
+            if os.getpgrp() == os.tcgetpgrp(sys.stdout.fileno()):
+                # Interactive mode
+                return False
+            else:
+                # Background mode
+                return True
+        # exception triggered if piping output to a file:
+        # i.e  goto list > /tmp/lol
+        except Exception:
+            pass
+    return False
+
+
+def healthcheck():
+    '''
+        Runs all healthchecks.
+        Currently there is only one:
+            - detect_unescaped_ampersand_url
+
+        returns GotoWarning if any issues detected.
+    '''
+    if detect_unescaped_ampersand_url():
+        if len(sys.argv) >= 3:
+            command = sys.argv[2]
+            magicword = sys.argv[3]
+            return GotoWarning(
+                'unescaped_ampersand_url_detected',
+                command=command,
+                magicword=magicword
+            )
+    # No issues detected
+    return None

--- a/goto/tests/test_end_to_end.sh
+++ b/goto/tests/test_end_to_end.sh
@@ -198,6 +198,14 @@ function test_06_goto_add {
     _cmd_should_fail "goto add test_add_no_uri"
     _failing_cmd_should_give_human_message "goto add test_add_no_uri"
     _projectfile_should_contain "$magicword"
+
+    # Invoking with & in uri, unescaped
+    # TODO: turns out to be hard to test actually, due to the fact that commands tested are always wrapped in quotes.
+    # _cmd_should_fail "goto add test_unescaped_ampersand_in_url http://lol?haha=hehe&hihi=hoho"
+    # _failing_cmd_should_give_human_message "goto add test_unescaped_ampersand_in_url http://lol?haha=hehe&hihi=hoho"
+    # TODO: add _projectfile_should_not_contain test_unescaped_ampersand_in_url check here
+    _cmd_should_succeed "goto add test_escaped_ampersand_in_url 'http://lol?haha=hehe&hihi=hoho'"
+    _projectfile_should_contain "test_escaped_ampersand_in_url"
 }
 
 function test_07_goto {

--- a/goto/the_real_goto.py
+++ b/goto/the_real_goto.py
@@ -3,11 +3,13 @@
 'Goto - the magic project that takes you where you need to be, now.'
 from __future__ import absolute_import, unicode_literals
 
+import os
 import sys
 import codecs
 
 from .gotomagic import text
 from .gotomagic.magic import GotoMagic
+from .gotomagic.utils import healthcheck
 
 from . import commands
 
@@ -20,6 +22,11 @@ except:
 
 
 def main():
+    err = healthcheck()
+    if err:
+        print(err.message)
+        exit(2)
+
     if len(sys.argv) < 3:
         output, _ = commands.usage()
         print(output)


### PR DESCRIPTION
implements feature in #94 - warn about & in url
    
    All write operations that takes uri as input, 
    now has detection of unescaped ampersand in the url.
    
    That would make goto run in the backround with only half of the url as
    argument, and the leftover parts of that url would be attempted executed
    by the shell -- most often resulting in "command not found".
    
    This is in fact a security issue, to the unawake user.
    
    http://example.com?a=b&ls
    
    Would execute ls.
    ls is harmless. But there are other commands which are not.
    Though, this is out of the scope of goto to stop (then we would have to
    implement a shell on top of the users shell .. and it is just not what
    we are aiming for :P ).


**Testing**
Turns out the way the commands are executing in the end-to-end framework is 
escaping the ampersand. So it is a bit hard to write automatic tests for it. Could be done, just a bit unsure how to aproach. 

Manual testing seems to work